### PR TITLE
Added TracingThrottleLogger

### DIFF
--- a/WebApiThrottle/ThrottleLogEntry.cs
+++ b/WebApiThrottle/ThrottleLogEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -17,5 +18,6 @@ namespace WebApiThrottle
         public long RateLimit { get; set; }
         public string RateLimitPeriod { get; set; }
         public DateTime LogDate { get; set; }
+        public HttpRequestMessage Request { get; set; }
     }
 }

--- a/WebApiThrottle/ThrottlingHandler.cs
+++ b/WebApiThrottle/ThrottlingHandler.cs
@@ -112,7 +112,7 @@ namespace WebApiThrottle
                         if (rateLimit > 0 && throttleCounter.TotalRequests > rateLimit)
                         {
                             //log blocked request
-                            if (Logger != null) Logger.Log(ComputeLogEntry(requestId, identity, throttleCounter, rateLimitPeriod.ToString(), rateLimit));
+                            if (Logger != null) Logger.Log(ComputeLogEntry(requestId, identity, throttleCounter, rateLimitPeriod.ToString(), rateLimit, request));
 
                             //break execution and return 409 
                             var message = string.IsNullOrEmpty(QuotaExceededMessage) ?
@@ -237,7 +237,7 @@ namespace WebApiThrottle
             return Task.FromResult(request.CreateResponse(HttpStatusCode.Conflict, message));
         }
 
-        private ThrottleLogEntry ComputeLogEntry(string requestId, RequestIndentity identity, ThrottleCounter throttleCounter, string rateLimitPeriod, long rateLimit)
+        private ThrottleLogEntry ComputeLogEntry(string requestId, RequestIndentity identity, ThrottleCounter throttleCounter, string rateLimitPeriod, long rateLimit, HttpRequestMessage request)
         {
             return new ThrottleLogEntry
                     {
@@ -249,7 +249,8 @@ namespace WebApiThrottle
                         RateLimitPeriod = rateLimitPeriod,
                         RequestId = requestId,
                         StartPeriod = throttleCounter.Timestamp,
-                        TotalRequests = throttleCounter.TotalRequests
+                        TotalRequests = throttleCounter.TotalRequests,
+                        Request = request
                     };
         }
     }

--- a/WebApiThrottle/TracingThrottleLogger.cs
+++ b/WebApiThrottle/TracingThrottleLogger.cs
@@ -1,0 +1,24 @@
+﻿using System.Web.Http.Tracing;
+
+namespace WebApiThrottle
+{
+    public class TracingThrottleLogger : IThrottleLogger
+    {
+        private readonly ITraceWriter traceWriter;
+        
+        public TracingThrottleLogger(ITraceWriter traceWriter)
+        {
+            this.traceWriter = traceWriter;
+        }
+       
+        public void Log(ThrottleLogEntry entry)
+        {
+            if (null != traceWriter)
+            {
+                traceWriter.Info(entry.Request, "WebApiThrottle", "{0} Request {1} to endpoint {2} from client {3} has been throttled (blocked), quota {4}/{5} exceeded by {6}",
+                    entry.LogDate, entry.RequestId, entry.ClientIp, entry.RateLimit,
+                    entry.Endpoint, entry.RateLimitPeriod, entry.TotalRequests);
+            }
+        }
+    }
+}

--- a/WebApiThrottle/WebApiThrottle.csproj
+++ b/WebApiThrottle/WebApiThrottle.csproj
@@ -71,6 +71,7 @@
     <Compile Include="CacheRepository.cs" />
     <Compile Include="RequestIndentity.cs" />
     <Compile Include="ThrottlingHandler.cs" />
+    <Compile Include="TracingThrottleLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Added TracingThrottleLogger to publish throttling messages to the native web api ITraceWritter if one is supplied.  The intention is that during the configuration, you could create an instance of this class, passing the ITraceWriter on the constructor.
