### PR TITLE
Added management of X-Rate-Limit

### DIFF
--- a/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
+++ b/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
@@ -32,6 +32,8 @@ namespace WebApiThrottle.Demo
             config.MessageHandlers.Add(new ThrottlingHandler(
                 policy: new ThrottlePolicy(perMinute: 20, perHour: 30, perDay: 35, perWeek: 3000)
                 {
+                    //ThrottleBy
+                    ThrotthleBy = WebApiThrottle.RateLimitPeriod.Hour,
                     //scope to IPs
                     IpThrottling = true,
                     IpRules = new Dictionary<string, RateLimits>

--- a/WebApiThrottle/ThrottlePolicy.cs
+++ b/WebApiThrottle/ThrottlePolicy.cs
@@ -58,6 +58,11 @@ namespace WebApiThrottle
         }
 
         /// <summary>
+        /// ThrottleBy will limit the check to a single measure enabling X-Rate-Limit-* Headers
+        /// </summary>
+        public RateLimitPeriod? ThrotthleBy { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether IP throttling is enabled.
         /// </summary>
         public bool IpThrottling { get; set; }


### PR DESCRIPTION
Hi Stefan,
following issue #30 I propose a possible implementation of X-Rate-Limit, by specifying a single throttle logic.
To make it explicit, I decided to add a nullable property in the the logic.

Obviously this limits the functionality of the library in a sense, but can be a useful addition if only one rate is required.