### PR TITLE
Fix #31

### DIFF
--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -193,7 +193,14 @@ namespace WebApiThrottle
 
             var id = string.Join("_", keyValues);
             var idBytes = Encoding.UTF8.GetBytes(id);
-            var hashBytes = new System.Security.Cryptography.SHA1Managed().ComputeHash(idBytes);
+
+            byte[] hashBytes;
+
+            using (var algorithm = System.Security.Cryptography.HashAlgorithm.Create("SHA1"))
+            {
+                hashBytes = algorithm.ComputeHash(idBytes);
+            }
+            
             var hex = BitConverter.ToString(hashBytes).Replace("-", string.Empty);
             return hex;
         }


### PR DESCRIPTION
Use ```HashAlgorithm.Create(string)``` so that .NET loads FIPS-compliant hash algorithms if available on the local machine. This also allows algorithms to be overridden as described [here](https://msdn.microsoft.com/en-us/library/693aff9y(v=vs.110).aspx).