### PR TITLE
Added the ability to resolve ipAddress'es based on custom logic e.g. custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,3 +518,21 @@ public class Startup
     }
 }
 ```
+
+### Custom ip address parsing
+
+If you need to extract client ip's from e.g. additional headers then you can plug in custom ipAddressParsers.
+There is an example implementation in the WebApiThrottle.Demo project - <code>WebApiThrottle.Demo.Net.CustomIpAddressParser</code>
+
+``` cs
+config.MessageHandlers.Add(new ThrottlingHandler(
+    policy: new ThrottlePolicy(perMinute: 20, perHour: 30, perDay: 35, perWeek: 3000)
+    {        
+        IpThrottling = true,
+        ///...
+    },
+    policyRepository: new PolicyCacheRepository(),
+    repository: new CacheRepository(),
+    logger: new TracingThrottleLogger(traceWriter),
+    ipAddressParser: new CustomIpAddressParser()));
+```

--- a/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
+++ b/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Tracing;
 using WebApiThrottle.Demo.Helpers;
-using WebApiThrottle.Demo.Providers;
+using WebApiThrottle.Demo.Net;
 
 namespace WebApiThrottle.Demo
 {

--- a/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
+++ b/WebApiThrottle.Demo/App_Start/WebApiConfig.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Tracing;
 using WebApiThrottle.Demo.Helpers;
+using WebApiThrottle.Demo.Providers;
 
 namespace WebApiThrottle.Demo
 {
@@ -61,7 +62,8 @@ namespace WebApiThrottle.Demo
                 },
                 policyRepository: new PolicyCacheRepository(),
                 repository: new CacheRepository(),
-                logger: new TracingThrottleLogger(traceWriter)));
+                logger: new TracingThrottleLogger(traceWriter),
+                ipAddressParser: new CustomIpAddressParser()));
 
             //Web API throttling handler load policy from web.config
             //config.MessageHandlers.Add(new ThrottlingHandler(

--- a/WebApiThrottle.Demo/Helpers/CustomThrottlingFilter.cs
+++ b/WebApiThrottle.Demo/Helpers/CustomThrottlingFilter.cs
@@ -24,9 +24,9 @@ namespace WebApiThrottle.Demo.Helpers
             };
         }
 
-        protected override HttpResponseMessage QuotaExceededResponse(HttpRequestMessage request, string message, HttpStatusCode responseCode, string retryAfter)
+        protected override HttpResponseMessage QuotaExceededResponse(HttpRequestMessage request, object content, HttpStatusCode responseCode, string retryAfter)
         {
-            var response = request.CreateResponse(responseCode, message);
+            var response = request.CreateResponse(responseCode, request);
             response.Headers.Add("Retry-After", new string[] { retryAfter });
             return response;
         }

--- a/WebApiThrottle.Demo/Net/CustomIpAddressParser.cs
+++ b/WebApiThrottle.Demo/Net/CustomIpAddressParser.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http;
 using WebApiThrottle.Net;
 
-namespace WebApiThrottle.Demo.Providers
+namespace WebApiThrottle.Demo.Net
 {
     public class CustomIpAddressParser : DefaultIpAddressParser
     {

--- a/WebApiThrottle.Demo/Providers/CustomIpAddressParser.cs
+++ b/WebApiThrottle.Demo/Providers/CustomIpAddressParser.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using WebApiThrottle.Net;
+
+namespace WebApiThrottle.Demo.Providers
+{
+    public class CustomIpAddressParser : DefaultIpAddressParser
+    {
+        public override IPAddress GetClientIp(HttpRequestMessage request)
+        {
+            const string customHeaderName = "true-client-ip";
+
+            if (request.Headers.Contains(customHeaderName))
+            {
+                IEnumerable<string> headerValues;
+
+                if (request.Headers.TryGetValues(customHeaderName, out headerValues))
+                {
+                    if (headerValues.Any())
+                    {
+                        return ParseIp(headerValues.FirstOrDefault().Trim());
+                    }
+                }
+            }
+
+            return base.GetClientIp(request);
+        }
+    }
+}

--- a/WebApiThrottle.Demo/WebApiThrottle.Demo.csproj
+++ b/WebApiThrottle.Demo/WebApiThrottle.Demo.csproj
@@ -15,13 +15,14 @@
     <AssemblyName>WebApiThrottle.Demo</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
-    <UseIISExpress>false</UseIISExpress>
+    <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -169,6 +170,7 @@
     <Compile Include="Helpers\CustomThrottlingFilter.cs" />
     <Compile Include="Helpers\CustomThrottlingHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Providers\CustomIpAddressParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Areas\HelpPage\HelpPage.css" />
@@ -253,7 +255,7 @@
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
   </Target>
   <ProjectExtensions>
-    <VisualStudio>
+    <!--<VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
@@ -261,6 +263,22 @@
           <DevelopmentServerPort>64984</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost/WebApiThrottle.Demo</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>-->
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>0</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:52842/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/WebApiThrottle.Demo/WebApiThrottle.Demo.csproj
+++ b/WebApiThrottle.Demo/WebApiThrottle.Demo.csproj
@@ -170,7 +170,7 @@
     <Compile Include="Helpers\CustomThrottlingFilter.cs" />
     <Compile Include="Helpers\CustomThrottlingHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Providers\CustomIpAddressParser.cs" />
+    <Compile Include="Net\CustomIpAddressParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Areas\HelpPage\HelpPage.css" />

--- a/WebApiThrottle.sln
+++ b/WebApiThrottle.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiThrottle.Demo", "WebApiThrottle.Demo\WebApiThrottle.Demo.csproj", "{B9BC1965-4DBD-413C-83D5-5FD9E819DCCE}"
 EndProject
@@ -20,6 +20,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{2CF9
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiThrottler.SelfHostOwinDemo", "WebApiThrottler.SelfHostOwinDemo\WebApiThrottler.SelfHostOwinDemo.csproj", "{22B91BA0-EFC9-4AF8-A24B-CF1CB476A50D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Readme", "Readme", "{D4FF492F-0AB9-4F78-9F9E-99ADE0D8C3AC}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/WebApiThrottle/Net/DefaultIpAddressParser.cs
+++ b/WebApiThrottle/Net/DefaultIpAddressParser.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.ServiceModel.Channels;
+using System.Web;
+
+namespace WebApiThrottle.Net
+{
+    public class DefaultIpAddressParser : IIpAddressParser
+    {
+        public bool ContainsIp(List<string> ipRules, string clientIp)
+        {
+            return IpAddressUtil.ContainsIp(ipRules, clientIp);
+        }
+
+        public bool ContainsIp(List<string> ipRules, string clientIp, out string rule)
+        {
+            return IpAddressUtil.ContainsIp(ipRules, clientIp, out rule);
+        }
+
+        public virtual IPAddress GetClientIp(HttpRequestMessage request)
+        {
+            IPAddress ipAddress;
+
+            if (request.Properties.ContainsKey("MS_HttpContext"))
+            {
+                var ok = IPAddress.TryParse(((HttpContextBase)request.Properties["MS_HttpContext"]).Request.UserHostAddress, out ipAddress);
+
+                if (ok)
+                {
+                    return ipAddress;
+                }
+            }
+
+            if (request.Properties.ContainsKey(RemoteEndpointMessageProperty.Name))
+            {
+                var ok = IPAddress.TryParse(((RemoteEndpointMessageProperty)request.Properties[RemoteEndpointMessageProperty.Name]).Address, out ipAddress);
+
+                if (ok)
+                {
+                    return ipAddress;
+                }
+            }
+
+            if (request.Properties.ContainsKey("MS_OwinContext"))
+            {
+                var ok = IPAddress.TryParse(((Microsoft.Owin.OwinContext)request.Properties["MS_OwinContext"]).Request.RemoteIpAddress, out ipAddress);
+
+                if (ok)
+                {
+                    return ipAddress;
+                }
+            }
+
+
+            return null;
+        }
+
+        public IPAddress ParseIp(string ipAddress)
+        {
+            return IpAddressUtil.ParseIp(ipAddress);
+        }
+    }
+}

--- a/WebApiThrottle/Net/IIpAddressParser.cs
+++ b/WebApiThrottle/Net/IIpAddressParser.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+
+namespace WebApiThrottle.Net
+{
+    public interface IIpAddressParser
+    {
+        bool ContainsIp(List<string> ipRules, string clientIp);
+
+        bool ContainsIp(List<string> ipRules, string clientIp, out string rule);
+
+        IPAddress GetClientIp(HttpRequestMessage request);
+
+        IPAddress ParseIp(string ipAddress);
+    }
+}

--- a/WebApiThrottle/Net/IpAddressUtil.cs
+++ b/WebApiThrottle/Net/IpAddressUtil.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace WebApiThrottle.Net
+{
+    public class IpAddressUtil
+    {
+        public static bool ContainsIp(List<string> ipRules, string clientIp)
+        {
+            var ip = ParseIp(clientIp);
+            if (ipRules != null && ipRules.Any())
+            {
+                foreach (var rule in ipRules)
+                {
+                    var range = new IPAddressRange(rule);
+                    if (range.Contains(ip))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool ContainsIp(List<string> ipRules, string clientIp, out string rule)
+        {
+            rule = null;
+            var ip = ParseIp(clientIp);
+            if (ipRules != null && ipRules.Any())
+            {
+                foreach (var r in ipRules)
+                {
+                    var range = new IPAddressRange(r);
+                    if (range.Contains(ip))
+                    {
+                        rule = r;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static IPAddress ParseIp(string ipAddress)
+        {
+            return IPAddress.Parse(ipAddress);
+        }
+    }
+}

--- a/WebApiThrottle/ThrottlingFilter.cs
+++ b/WebApiThrottle/ThrottlingFilter.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
+using WebApiThrottle.Net;
 
 namespace WebApiThrottle
 {
@@ -50,12 +51,23 @@ namespace WebApiThrottle
         /// <param name="logger">
         /// The logger.
         /// </param>
-        public ThrottlingFilter(ThrottlePolicy policy, IPolicyRepository policyRepository, IThrottleRepository repository, IThrottleLogger logger)
+        /// <param name="ipAddressParser">
+        /// The ip address provider
+        /// </param>
+        public ThrottlingFilter(ThrottlePolicy policy, 
+            IPolicyRepository policyRepository, 
+            IThrottleRepository repository, 
+            IThrottleLogger logger, 
+            IIpAddressParser ipAddressParser = null)
         {
             core = new ThrottlingCore();
             core.Repository = repository;
             Repository = repository;
             Logger = logger;
+            if (ipAddressParser != null)
+            {
+                core.IpAddressParser = ipAddressParser;
+            }
 
             QuotaExceededResponseCode = (HttpStatusCode)429;
 

--- a/WebApiThrottle/ThrottlingHandler.cs
+++ b/WebApiThrottle/ThrottlingHandler.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using WebApiThrottle.Net;
 
 namespace WebApiThrottle
 {
@@ -49,12 +50,24 @@ namespace WebApiThrottle
         /// <param name="logger">
         /// The logger.
         /// </param>
-        public ThrottlingHandler(ThrottlePolicy policy, IPolicyRepository policyRepository, IThrottleRepository repository, IThrottleLogger logger)
+        /// <param name="ipAddressParser">
+        /// The IpAddressParser
+        /// </param>
+        public ThrottlingHandler(ThrottlePolicy policy, 
+            IPolicyRepository policyRepository, 
+            IThrottleRepository repository, 
+            IThrottleLogger logger,
+            IIpAddressParser ipAddressParser = null)
         {
             core = new ThrottlingCore();
             core.Repository = repository;
             Repository = repository;
             Logger = logger;
+
+            if (ipAddressParser != null)
+            {
+                core.IpAddressParser = ipAddressParser;
+            }
 
             QuotaExceededResponseCode = (HttpStatusCode)429;
 

--- a/WebApiThrottle/ThrottlingMiddleware.cs
+++ b/WebApiThrottle/ThrottlingMiddleware.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using WebApiThrottle.Net;
 
 namespace WebApiThrottle
 {
@@ -45,13 +46,26 @@ namespace WebApiThrottle
         /// <param name="logger">
         /// The logger.
         /// </param>
-        public ThrottlingMiddleware(OwinMiddleware next, ThrottlePolicy policy, IPolicyRepository policyRepository, IThrottleRepository repository, IThrottleLogger logger)
+        /// <param name="ipAddressParser">
+        /// The IpAddressParser
+        /// </param>
+        public ThrottlingMiddleware(OwinMiddleware next, 
+            ThrottlePolicy policy, 
+            IPolicyRepository policyRepository, 
+            IThrottleRepository repository, 
+            IThrottleLogger logger,
+            IIpAddressParser ipAddressParser)
             : base(next)
         {
             core = new ThrottlingCore();
             core.Repository = repository;
             Repository = repository;
             Logger = logger;
+
+            if (ipAddressParser != null)
+            {
+                core.IpAddressParser = ipAddressParser;
+            }
 
             QuotaExceededResponseCode = (HttpStatusCode)429;
 

--- a/WebApiThrottle/WebApiThrottle.csproj
+++ b/WebApiThrottle/WebApiThrottle.csproj
@@ -69,6 +69,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\DisableThrottingAttribute.cs" />
+    <Compile Include="Net\DefaultIpAddressParser.cs" />
+    <Compile Include="Net\IIpAddressParser.cs" />
+    <Compile Include="Net\IpAddressUtil.cs" />
     <Compile Include="Repositories\IPolicyRepository.cs" />
     <Compile Include="Repositories\PolicyMemoryCacheRepository.cs" />
     <Compile Include="Repositories\PolicyCacheRepository.cs" />


### PR DESCRIPTION
There is an example implementation of this in the demo project: 
WebApiThrottle.Demo.Net.CustomIpAddressParser 

The ThrottlingCore takes a default IP address parser. Depending on needs this can then be overridden.