### PR TITLE
Added option to use the controller action as the throttle key

### DIFF
--- a/WebApiThrottle/Models/EndpointThrottlingMethod.cs
+++ b/WebApiThrottle/Models/EndpointThrottlingMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace WebApiThrottle.Models
+{
+    public enum EndpointThrottlingMethod
+    {
+        Url,
+        Action
+    }
+}

--- a/WebApiThrottle/Models/RequestIdentity.cs
+++ b/WebApiThrottle/Models/RequestIdentity.cs
@@ -17,5 +17,9 @@ namespace WebApiThrottle
         public string ClientKey { get; set; }
 
         public string Endpoint { get; set; }
+
+        public string ActionName { get; set; }
+
+        public string ControllerName { get; set; }
     }
 }

--- a/WebApiThrottle/ThrottlePolicy.cs
+++ b/WebApiThrottle/ThrottlePolicy.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 namespace WebApiThrottle
 {
+    using Models;
+
     /// <summary>
     /// Rate limits policy
     /// </summary>
@@ -79,6 +81,8 @@ namespace WebApiThrottle
         /// Gets or sets a value indicating whether route throttling is enabled
         /// </summary>
         public bool EndpointThrottling { get; set; }
+
+        public EndpointThrottlingMethod EndpointThrottleMethod { get; set; }
 
         public List<string> EndpointWhitelist { get; set; }
 

--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -8,6 +8,8 @@ using WebApiThrottle.Net;
 
 namespace WebApiThrottle
 {
+    using Models;
+
     /// <summary>
     /// Common code shared between ThrottlingHandler and ThrottlingFilter
     /// </summary>
@@ -130,7 +132,17 @@ namespace WebApiThrottle
 
             if (Policy.EndpointThrottling)
             {
-                keyValues.Add(requestIdentity.Endpoint);
+                if (Policy.EndpointThrottleMethod == EndpointThrottlingMethod.Action &&
+                    !string.IsNullOrWhiteSpace(requestIdentity.ActionName) &&
+                    !string.IsNullOrWhiteSpace(requestIdentity.ControllerName))
+                {
+                    //TODO: think of a better way to do this
+                    keyValues.Add(requestIdentity.ControllerName + "." + requestIdentity.ActionName);
+                }
+                else if (Policy.EndpointThrottleMethod == EndpointThrottlingMethod.Url)
+                {
+                    keyValues.Add(requestIdentity.Endpoint);
+                }
             }
 
             keyValues.Add(period.ToString());

--- a/WebApiThrottle/ThrottlingFilter.cs
+++ b/WebApiThrottle/ThrottlingFilter.cs
@@ -228,6 +228,14 @@ namespace WebApiThrottle
             entry.ClientIp = core.GetClientIp(request).ToString();
             entry.Endpoint = request.RequestUri.AbsolutePath.ToLowerInvariant();
             entry.ClientKey = request.Headers.Contains("Authorization-Token") ? request.Headers.GetValues("Authorization-Token").First() : "anon";
+            
+            var actionDescriptor = request.GetActionDescriptor();
+            if (actionDescriptor == null)
+                return entry;
+
+            entry.ActionName = actionDescriptor.ActionName;
+            if(actionDescriptor.ControllerDescriptor != null)
+                entry.ControllerName = actionDescriptor.ControllerDescriptor.ControllerName;
 
             return entry;
         }

--- a/WebApiThrottle/WebApiThrottle.csproj
+++ b/WebApiThrottle/WebApiThrottle.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\DisableThrottingAttribute.cs" />
+    <Compile Include="Models\EndpointThrottlingMethod.cs" />
     <Compile Include="Net\DefaultIpAddressParser.cs" />
     <Compile Include="Net\IIpAddressParser.cs" />
     <Compile Include="Net\IpAddressUtil.cs" />


### PR DESCRIPTION
I had the need to throttle based on the controller and action name.

As I was using attribute routing for a restful webapi, every URL was different but all used the same action (eg `/objects/{id}`)