### PR TITLE
Handle X-Forward-For when proxys are being used

### DIFF
--- a/WebApiThrottle/Net/DefaultIpAddressParser.cs
+++ b/WebApiThrottle/Net/DefaultIpAddressParser.cs
@@ -21,35 +21,14 @@ namespace WebApiThrottle.Net
         public virtual IPAddress GetClientIp(HttpRequestMessage request)
         {
             IPAddress ipAddress;
+            
+            // use the extension method to get the client ip address as this will
+            // handle the X-Forward-For header
+            var ok = IPAddress.TryParse(request.GetClientIpAddress(), out ipAddress);
 
-            if (request.Properties.ContainsKey("MS_HttpContext"))
+            if (ok)
             {
-                var ok = IPAddress.TryParse(((HttpContextBase)request.Properties["MS_HttpContext"]).Request.UserHostAddress, out ipAddress);
-
-                if (ok)
-                {
-                    return ipAddress;
-                }
-            }
-
-            if (request.Properties.ContainsKey(RemoteEndpointMessageProperty.Name))
-            {
-                var ok = IPAddress.TryParse(((RemoteEndpointMessageProperty)request.Properties[RemoteEndpointMessageProperty.Name]).Address, out ipAddress);
-
-                if (ok)
-                {
-                    return ipAddress;
-                }
-            }
-
-            if (request.Properties.ContainsKey("MS_OwinContext"))
-            {
-                var ok = IPAddress.TryParse(((Microsoft.Owin.OwinContext)request.Properties["MS_OwinContext"]).Request.RemoteIpAddress, out ipAddress);
-
-                if (ok)
-                {
-                    return ipAddress;
-                }
+                return ipAddress;
             }
 
 
@@ -60,5 +39,6 @@ namespace WebApiThrottle.Net
         {
             return IpAddressUtil.ParseIp(ipAddress);
         }
+
     }
 }

--- a/WebApiThrottle/Net/HttpRequestExtensions.cs
+++ b/WebApiThrottle/Net/HttpRequestExtensions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.ServiceModel.Channels;
+using System.Web;
+
+namespace WebApiThrottle.Net
+{
+    public static class HttpRequestExtensions
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static string GetClientIpAddress(this HttpRequestMessage request)
+        {
+            // Always return all zeroes for any failure (my calling code expects it)
+            string ipAddress = "0.0.0.0";
+
+            if (request.Properties.ContainsKey("MS_HttpContext"))
+            {
+                ipAddress = ((HttpContextBase)request.Properties["MS_HttpContext"]).Request.UserHostAddress;
+            }
+            else if (request.Properties.ContainsKey(RemoteEndpointMessageProperty.Name))
+            {
+                ipAddress = ((RemoteEndpointMessageProperty)request.Properties[RemoteEndpointMessageProperty.Name]).Address;
+            }
+
+            if (request.Properties.ContainsKey("MS_OwinContext"))
+            {
+                ipAddress = ((Microsoft.Owin.OwinContext) request.Properties["MS_OwinContext"]).Request.RemoteIpAddress;
+            }
+
+            // get the X-Forward-For headers (should only really be one)
+            IEnumerable<string> xForwardForList;
+            if (!request.Headers.TryGetValues("X-Forwarded-For", out xForwardForList))
+            {
+               return ipAddress;
+            }
+
+            var xForwardedFor = xForwardForList.FirstOrDefault();
+
+            // check that we have a value
+            if (string.IsNullOrEmpty(xForwardedFor))
+            {
+                return ipAddress;
+            }
+
+            // Get a list of public ip addresses in the X_FORWARDED_FOR variable
+            var publicForwardingIps = xForwardedFor.Split(',').Where(ip => !IpAddressUtil.IsPrivateIpAddress(ip)).ToList();
+
+            // If we found any, return the last one, otherwise return the user host address
+            return publicForwardingIps.Any() ? publicForwardingIps.Last() : ipAddress;
+
+        }
+
+    }
+}

--- a/WebApiThrottle/Net/IpAddressUtil.cs
+++ b/WebApiThrottle/Net/IpAddressUtil.cs
@@ -48,5 +48,30 @@ namespace WebApiThrottle.Net
         {
             return IPAddress.Parse(ipAddress);
         }
+
+        public static bool IsPrivateIpAddress(string ipAddress)
+        {
+            // http://en.wikipedia.org/wiki/Private_network
+            // Private IP Addresses are: 
+            //  24-bit block: 10.0.0.0 through 10.255.255.255
+            //  20-bit block: 172.16.0.0 through 172.31.255.255
+            //  16-bit block: 192.168.0.0 through 192.168.255.255
+            //  Link-local addresses: 169.254.0.0 through 169.254.255.255 (http://en.wikipedia.org/wiki/Link-local_address)
+
+            var ip = IPAddress.Parse(ipAddress);
+            var octets = ip.GetAddressBytes();
+
+            var is24BitBlock = octets[0] == 10;
+            if (is24BitBlock) return true; // Return to prevent further processing
+
+            var is20BitBlock = octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31;
+            if (is20BitBlock) return true; // Return to prevent further processing
+
+            var is16BitBlock = octets[0] == 192 && octets[1] == 168;
+            if (is16BitBlock) return true; // Return to prevent further processing
+
+            var isLinkLocalAddress = octets[0] == 169 && octets[1] == 254;
+            return isLinkLocalAddress;
+        }
     }
 }

--- a/WebApiThrottle/WebApiThrottle.csproj
+++ b/WebApiThrottle/WebApiThrottle.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <Compile Include="Attributes\DisableThrottingAttribute.cs" />
     <Compile Include="Net\DefaultIpAddressParser.cs" />
+    <Compile Include="Net\HttpRequestExtensions.cs" />
     <Compile Include="Net\IIpAddressParser.cs" />
     <Compile Include="Net\IpAddressUtil.cs" />
     <Compile Include="Repositories\IPolicyRepository.cs" />


### PR DESCRIPTION
Currently it does not look like the correct client ip address will be obtained when a proxy is being used that uses the X-Forward-For to hold the original clients ip address