### PR TITLE
Allow RequestIdentity object to force a whitelisting of a request.

### DIFF
--- a/WebApiThrottle/Models/RequestIdentity.cs
+++ b/WebApiThrottle/Models/RequestIdentity.cs
@@ -17,5 +17,7 @@ namespace WebApiThrottle
         public string ClientKey { get; set; }
 
         public string Endpoint { get; set; }
+
+        public bool ForceWhiteList { get; set; }
     }
 }

--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -83,6 +83,11 @@ namespace WebApiThrottle
 
         internal bool IsWhitelisted(RequestIdentity requestIdentity)
         {
+            if (requestIdentity.ForceWhiteList)
+            {
+                return true;
+            }
+
             if (Policy.IpThrottling)
             {
                 if (Policy.IpWhitelist != null && ContainsIp(Policy.IpWhitelist, requestIdentity.ClientIp))


### PR DESCRIPTION
This is a practical little feature in case you want to whitelist certain types of requests. Like OPTIONS.