### PR TITLE
Ipaddress parse fix to handle X-Forwarded-For with ports

### DIFF
--- a/WebApiThrottle.Tests/IpAddressUtilTests.cs
+++ b/WebApiThrottle.Tests/IpAddressUtilTests.cs
@@ -57,5 +57,13 @@ namespace WebApiThrottle.Tests
 
             Assert.Equal(true, result);
         }
+
+        [Fact]
+        public void IsPrivateIpAddress_PublicIpAddressWithInitialSpace_ReturnsFalse()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress(" 8.8.8.8");
+
+            Assert.Equal(false, result);
+        }
     }
 }

--- a/WebApiThrottle.Tests/IpAddressUtilTests.cs
+++ b/WebApiThrottle.Tests/IpAddressUtilTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WebApiThrottle.Net;
+using Xunit;
+
+namespace WebApiThrottle.Tests
+{
+    public class IpAddressUtilTests
+    {
+        [Fact]
+        public void IsPrivateIpAddress_PrivateAddress_ReturnsTrue()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("10.0.0.1");
+
+            Assert.Equal(true, result);
+        }
+
+        [Fact]
+        public void IsPrivateIpAddress_PublicAddress_ReturnsFalse()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("8.8.8.8");
+
+            Assert.Equal(false, result);
+        }
+
+        [Fact]
+        public void IsPrivateIpAddress_PrivateAddressWithPort_ReturnsTrue()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("10.0.0.1:5555");
+
+            Assert.Equal(true, result);
+        }
+    }
+}

--- a/WebApiThrottle.Tests/IpAddressUtilTests.cs
+++ b/WebApiThrottle.Tests/IpAddressUtilTests.cs
@@ -25,11 +25,35 @@ namespace WebApiThrottle.Tests
 
             Assert.Equal(false, result);
         }
+        
+        [Fact]
+        public void IsPrivateIpAddress_PublicAddressIpv6_ReturnsFalse()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("2001:4860:4860::8888");
+
+            Assert.Equal(false, result);
+        }
+
+        [Fact]
+        public void IsPrivateIpAddress_PrivateAddressIpv6_ReturnsFalse()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("fd74:20cf:81a2::");
+
+            Assert.Equal(true, result);
+        }
 
         [Fact]
         public void IsPrivateIpAddress_PrivateAddressWithPort_ReturnsTrue()
         {
             bool result = IpAddressUtil.IsPrivateIpAddress("10.0.0.1:5555");
+
+            Assert.Equal(true, result);
+        }
+
+        [Fact]
+        public void IsPrivateIpAddress_PrivateAddressIpv6WithPort_ReturnsTrue()
+        {
+            bool result = IpAddressUtil.IsPrivateIpAddress("[fd74:20cf:81a2::]:5555");
 
             Assert.Equal(true, result);
         }

--- a/WebApiThrottle.Tests/Properties/AssemblyInfo.cs
+++ b/WebApiThrottle.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebApiThrottle.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiThrottle.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a2db243c-dfd4-4e22-9753-ed95cf6fc21e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WebApiThrottle.Tests/WebApiThrottle.Tests.csproj
+++ b/WebApiThrottle.Tests/WebApiThrottle.Tests.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebApiThrottle.Tests</RootNamespace>
+    <AssemblyName>WebApiThrottle.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IpAddressUtilTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WebApiThrottle.StrongName\WebApiThrottle.StrongName.csproj">
+      <Project>{FBF3012B-08EF-408C-9E7D-175ABF286CB4}</Project>
+      <Name>WebApiThrottle.StrongName</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WebApiThrottle.Tests/packages.config
+++ b/WebApiThrottle.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+</packages>

--- a/WebApiThrottle.sln
+++ b/WebApiThrottle.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiThrottle.WebApiDemo",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiThrottle.StrongName", "WebApiThrottle.StrongName\WebApiThrottle.StrongName.csproj", "{FBF3012B-08EF-408C-9E7D-175ABF286CB4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiThrottle.Tests", "WebApiThrottle.Tests\WebApiThrottle.Tests.csproj", "{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{FBF3012B-08EF-408C-9E7D-175ABF286CB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBF3012B-08EF-408C-9E7D-175ABF286CB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBF3012B-08EF-408C-9E7D-175ABF286CB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2DB243C-DFD4-4E22-9753-ED95CF6FC21E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebApiThrottle/Net/DefaultIpAddressParser.cs
+++ b/WebApiThrottle/Net/DefaultIpAddressParser.cs
@@ -20,19 +20,7 @@ namespace WebApiThrottle.Net
 
         public virtual IPAddress GetClientIp(HttpRequestMessage request)
         {
-            IPAddress ipAddress;
-            
-            // use the extension method to get the client ip address as this will
-            // handle the X-Forward-For header
-            var ok = IPAddress.TryParse(request.GetClientIpAddress(), out ipAddress);
-
-            if (ok)
-            {
-                return ipAddress;
-            }
-
-
-            return null;
+            return ParseIp(request.GetClientIpAddress());
         }
 
         public IPAddress ParseIp(string ipAddress)

--- a/WebApiThrottle/Net/IpAddressUtil.cs
+++ b/WebApiThrottle/Net/IpAddressUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -46,6 +47,13 @@ namespace WebApiThrottle.Net
 
         public static IPAddress ParseIp(string ipAddress)
         {
+            int portDelimiterPos = ipAddress.IndexOf(":", StringComparison.InvariantCultureIgnoreCase);
+            if (portDelimiterPos != -1)
+            {
+                ipAddress = ipAddress.Substring(0, portDelimiterPos);
+            }
+
+
             return IPAddress.Parse(ipAddress);
         }
 
@@ -58,7 +66,7 @@ namespace WebApiThrottle.Net
             //  16-bit block: 192.168.0.0 through 192.168.255.255
             //  Link-local addresses: 169.254.0.0 through 169.254.255.255 (http://en.wikipedia.org/wiki/Link-local_address)
 
-            var ip = IPAddress.Parse(ipAddress);
+            var ip = ParseIp(ipAddress);
             var octets = ip.GetAddressBytes();
 
             var is24BitBlock = octets[0] == 10;

--- a/WebApiThrottle/Net/IpAddressUtil.cs
+++ b/WebApiThrottle/Net/IpAddressUtil.cs
@@ -48,6 +48,7 @@ namespace WebApiThrottle.Net
 
         public static IPAddress ParseIp(string ipAddress)
         {
+            ipAddress = ipAddress.Trim();
             int portDelimiterPos = ipAddress.LastIndexOf(":", StringComparison.InvariantCultureIgnoreCase);
             bool ipv6WithPortStart = ipAddress.StartsWith("[");
             int ipv6End = ipAddress.IndexOf("]");

--- a/WebApiThrottle/Net/IpAddressUtil.cs
+++ b/WebApiThrottle/Net/IpAddressUtil.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 
@@ -47,13 +48,16 @@ namespace WebApiThrottle.Net
 
         public static IPAddress ParseIp(string ipAddress)
         {
-            int portDelimiterPos = ipAddress.IndexOf(":", StringComparison.InvariantCultureIgnoreCase);
-            if (portDelimiterPos != -1)
+            int portDelimiterPos = ipAddress.LastIndexOf(":", StringComparison.InvariantCultureIgnoreCase);
+            bool ipv6WithPortStart = ipAddress.StartsWith("[");
+            int ipv6End = ipAddress.IndexOf("]");
+            if (portDelimiterPos != -1
+                && portDelimiterPos == ipAddress.IndexOf(":", StringComparison.InvariantCultureIgnoreCase)
+                || ipv6WithPortStart && ipv6End != -1 && ipv6End < portDelimiterPos)
             {
                 ipAddress = ipAddress.Substring(0, portDelimiterPos);
             }
-
-
+            
             return IPAddress.Parse(ipAddress);
         }
 
@@ -69,17 +73,27 @@ namespace WebApiThrottle.Net
             var ip = ParseIp(ipAddress);
             var octets = ip.GetAddressBytes();
 
-            var is24BitBlock = octets[0] == 10;
-            if (is24BitBlock) return true; // Return to prevent further processing
+            bool isIpv6 = octets.Length == 16;
 
-            var is20BitBlock = octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31;
-            if (is20BitBlock) return true; // Return to prevent further processing
+            if (isIpv6)
+            {
+                bool isUniqueLocalAddress = octets[0] == 253;
+                return isUniqueLocalAddress;
+            }
+            else
+            {
+                var is24BitBlock = octets[0] == 10;
+                if (is24BitBlock) return true; // Return to prevent further processing
 
-            var is16BitBlock = octets[0] == 192 && octets[1] == 168;
-            if (is16BitBlock) return true; // Return to prevent further processing
+                var is20BitBlock = octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31;
+                if (is20BitBlock) return true; // Return to prevent further processing
 
-            var isLinkLocalAddress = octets[0] == 169 && octets[1] == 254;
-            return isLinkLocalAddress;
+                var is16BitBlock = octets[0] == 192 && octets[1] == 168;
+                if (is16BitBlock) return true; // Return to prevent further processing
+
+                var isLinkLocalAddress = octets[0] == 169 && octets[1] == 254;
+                return isLinkLocalAddress;
+            }
         }
     }
 }


### PR DESCRIPTION
I had the same problem as https://github.com/stefanprodan/WebApiThrottle/issues/34 with X-Forwarded-For containing port numbers. This pull request adds add check for port numbers and removes them before using the same parse logic as previously.

It also adds a test project for the parse code.