### PR TITLE
Improved Async Support for building identity

### DIFF
--- a/WebApiThrottle.WebApiDemo/Helpers/CustomThrottlingHandler.cs
+++ b/WebApiThrottle.WebApiDemo/Helpers/CustomThrottlingHandler.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web;
 
 namespace WebApiThrottle.WebApiDemo.Helpers
 {
     public class CustomThrottlingHandler : ThrottlingHandler
     {
-        protected override RequestIdentity SetIdentity(System.Net.Http.HttpRequestMessage request)
+        protected override Task<RequestIdentity> SetIdentityAsync(System.Net.Http.HttpRequestMessage request)
         {
-            return new RequestIdentity()
+            return Task.FromResult(new RequestIdentity()
             {
                 ClientKey = request.Headers.Contains("Authorization-Key") ? request.Headers.GetValues("Authorization-Key").First() : "anon",
                 ClientIp = base.GetClientIp(request).ToString(),
                 Endpoint = request.RequestUri.AbsolutePath.ToLowerInvariant()
-            };
+            });
         }
     }
 }

--- a/WebApiThrottle/ThrottlingMiddleware.cs
+++ b/WebApiThrottle/ThrottlingMiddleware.cs
@@ -140,7 +140,7 @@ namespace WebApiThrottle
             core.Repository = Repository;
             core.Policy = policy;
 
-            var identity = SetIdentity(request);
+            var identity = await SetIdentityAsync(request);
 
             if (core.IsWhitelisted(identity))
             {
@@ -213,7 +213,13 @@ namespace WebApiThrottle
             await Next.Invoke(context);
         }
 
+        [Obsolete("This method is deprecated, use SetIdentityAsync instead")]
         protected virtual RequestIdentity SetIdentity(IOwinRequest request)
+        {
+            throw new NotImplementedException("This method is deprecated, use SetIdentityAsync instead");
+        }
+
+        protected virtual Task<RequestIdentity> SetIdentityAsync(IOwinRequest request)
         {
             var entry = new RequestIdentity();
             entry.ClientIp = request.RemoteIpAddress;
@@ -222,7 +228,7 @@ namespace WebApiThrottle
                 ? request.Headers.GetValues("Authorization-Token").First()
                 : "anon";
 
-            return entry;
+            return Task.FromResult(entry);
         }
 
         protected virtual string ComputeThrottleKey(RequestIdentity requestIdentity, RateLimitPeriod period)


### PR DESCRIPTION
Changes in the three implementations of the  Throttling moving from SetIdentity (that was marked as obsolete) to a SetIdentityAsync.

The decision of creating a new method was to avoid breaking the signature, however the synchronous one doesn't make sense anymore.