### PR TITLE
Fixed ability to override ComputeThrottleKey

### DIFF
--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -184,15 +184,13 @@ namespace WebApiThrottle
             return defRates;
         }
 
-        internal ThrottleCounter ProcessRequest(RequestIdentity requestIdentity, TimeSpan timeSpan, RateLimitPeriod period, out string id)
+        internal ThrottleCounter ProcessRequest(TimeSpan timeSpan, string id)
         {
             var throttleCounter = new ThrottleCounter()
             {
                 Timestamp = DateTime.UtcNow,
                 TotalRequests = 1
             };
-
-            id = ComputeThrottleKey(requestIdentity, period);
 
             // serial reads and writes
             lock (ProcessLocker)

--- a/WebApiThrottle/ThrottlingFilter.cs
+++ b/WebApiThrottle/ThrottlingFilter.cs
@@ -181,8 +181,8 @@ namespace WebApiThrottle
                         if (rateLimit > 0)
                         {
                             // increment counter
-                            string requestId;
-                            var throttleCounter = core.ProcessRequest(identity, timeSpan, rateLimitPeriod, out requestId);
+                            var requestId = ComputeThrottleKey(identity, rateLimitPeriod); 
+                            var throttleCounter = core.ProcessRequest(timeSpan, requestId);
 
                             // check if key expired
                             if (throttleCounter.Timestamp + timeSpan < DateTime.UtcNow)

--- a/WebApiThrottle/ThrottlingHandler.cs
+++ b/WebApiThrottle/ThrottlingHandler.cs
@@ -177,8 +177,8 @@ namespace WebApiThrottle
                 if (rateLimit > 0)
                 {
                     // increment counter
-                    string requestId;
-                    var throttleCounter = core.ProcessRequest(identity, timeSpan, rateLimitPeriod, out requestId);
+                    var requestId = ComputeThrottleKey(identity, rateLimitPeriod);
+                    var throttleCounter = core.ProcessRequest(timeSpan, requestId);
 
                     // check if key expired
                     if (throttleCounter.Timestamp + timeSpan < DateTime.UtcNow)

--- a/WebApiThrottle/ThrottlingMiddleware.cs
+++ b/WebApiThrottle/ThrottlingMiddleware.cs
@@ -173,8 +173,8 @@ namespace WebApiThrottle
                 if (rateLimit > 0)
                 {
                     // increment counter
-                    string requestId;
-                    var throttleCounter = core.ProcessRequest(identity, timeSpan, rateLimitPeriod, out requestId);
+                    var requestId = ComputeThrottleKey(identity, rateLimitPeriod);
+                    var throttleCounter = core.ProcessRequest(timeSpan, requestId);
 
                     // check if key expired
                     if (throttleCounter.Timestamp + timeSpan < DateTime.UtcNow)


### PR DESCRIPTION
Passing in repository key from throttling implementations' ComputeThrottleKey to ProcessRequest instead of always using core ComputeThrottleKey method.