### PR TITLE
Fix: Setting ThrottlePolicy.Rates to public

### DIFF
--- a/WebApiThrottle/ThrottlePolicy.cs
+++ b/WebApiThrottle/ThrottlePolicy.cs
@@ -89,7 +89,7 @@ namespace WebApiThrottle
         /// </summary>
         public bool StackBlockedRequests { get; set; }
 
-        internal Dictionary<RateLimitPeriod, long> Rates { get; set; }
+        public Dictionary<RateLimitPeriod, long> Rates { get; set; }
 
         public static ThrottlePolicy FromStore(IThrottlePolicyProvider provider)
         {


### PR DESCRIPTION
This allows policies to properly serialize and be deserialized.