### PR TITLE
Leverage SHA1.Create when Creating HashAlgorithm

### DIFF
--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -145,7 +145,7 @@ namespace WebApiThrottle
 
             byte[] hashBytes;
 
-            using (var algorithm = System.Security.Cryptography.HashAlgorithm.Create("SHA1"))
+            using (var algorithm = System.Security.Cryptography.SHA1.Create())
             {
                 hashBytes = algorithm.ComputeHash(idBytes);
             }


### PR DESCRIPTION
The compute throttle key function utilizes `HashAlgorithm.Create(string hashName)` which has the possibility of returning null. A null check is not done on the algorithm prior to leveraging it to compute the hash, which can cause a `NullReferenceException` to be thrown and handled. 

I'm leveraging the underlying handler code to help compute the hash and retrieve the counter from my `IThrottleRepository` implementation, but the very first request to compute the hash throws the `NullReferenceException`. I've overridden the function locally to leverage the SHA1.Create() method and the code no longer throws an exception.