### PR TITLE
Allow client keys to be compared in a case-insensitive manner.

### DIFF
--- a/WebApiThrottle.Tests/WebApiThrottle.Tests.csproj
+++ b/WebApiThrottle.Tests/WebApiThrottle.Tests.csproj
@@ -68,6 +68,9 @@
       <Name>WebApiThrottle.StrongName</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/WebApiThrottle/ThrottlePolicy.cs
+++ b/WebApiThrottle/ThrottlePolicy.cs
@@ -21,6 +21,7 @@ namespace WebApiThrottle
             EndpointWhitelist = new List<string>();
             EndpointRules = new Dictionary<string, RateLimits>();
             Rates = new Dictionary<RateLimitPeriod, long>();
+            StringComparerForClients = StringComparer.CurrentCulture;
         }
 
         /// <summary>
@@ -90,6 +91,7 @@ namespace WebApiThrottle
         public bool StackBlockedRequests { get; set; }
 
         public Dictionary<RateLimitPeriod, long> Rates { get; set; }
+        public IEqualityComparer<string> StringComparerForClients { get; set; }
 
         public static ThrottlePolicy FromStore(IThrottlePolicyProvider provider)
         {

--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -98,7 +98,7 @@ namespace WebApiThrottle
 
             if (Policy.ClientThrottling)
             {
-                if (Policy.ClientWhitelist != null && Policy.ClientWhitelist.Contains(requestIdentity.ClientKey))
+                if (Policy.ClientWhitelist != null && Policy.ClientWhitelist.Contains(requestIdentity.ClientKey, Policy.StringComparerForClients))
                 {
                     return true;
                 }


### PR DESCRIPTION
Default is still case-sensitive.