### PR TITLE
Made GetLimit of EnableThrottlingAttribute a virtual method

### DIFF
--- a/WebApiThrottle/Attributes/EnableThrottlingAttribute.cs
+++ b/WebApiThrottle/Attributes/EnableThrottlingAttribute.cs
@@ -19,7 +19,7 @@ namespace WebApiThrottle
 
         public long PerWeek { get; set; }
 
-        public long GetLimit(RateLimitPeriod period)
+        public virtual long GetLimit(RateLimitPeriod period)
         {
             switch (period)
             {


### PR DESCRIPTION
Having the GetLimit() method in EnableThrottlingAttribute be virtual really helps with creating subclasses that inherit EnableThrottlingAttribute.

I created class that inherited EnableThrottlingAttribute, where I defined a throttling policy at compile time. At runtime, it pulls the throttling policy from the web.config file. In order to make this work, I had to make GetLimit() virtual and override it, reading the limit settings from the configuration.