### PR TITLE
Only apply rules if they exist

### DIFF
--- a/WebApiThrottle/ThrottlingCore.cs
+++ b/WebApiThrottle/ThrottlingCore.cs
@@ -249,7 +249,7 @@ namespace WebApiThrottle
         internal void ApplyRules(RequestIdentity identity, TimeSpan timeSpan, RateLimitPeriod rateLimitPeriod, ref long rateLimit)
         {
             // apply endpoint rate limits
-            if (Policy.EndpointRules != null)
+            if (Policy.EndpointRules?.Any() == true)
             {
                 var rules = Policy.EndpointRules.Where(x => identity.Endpoint.IndexOf(x.Key, 0, StringComparison.InvariantCultureIgnoreCase) != -1).ToList();
                 if (rules.Any())
@@ -265,7 +265,7 @@ namespace WebApiThrottle
             }
 
             // apply custom rate limit for clients that will override endpoint limits
-            if (Policy.ClientRules != null && Policy.ClientRules.Keys.Contains(identity.ClientKey))
+            if (Policy.ClientRules?.Any() == true && Policy.ClientRules.Keys.Contains(identity.ClientKey))
             {
                 var limit = Policy.ClientRules[identity.ClientKey].GetLimit(rateLimitPeriod);
                 if (limit > 0)
@@ -276,7 +276,7 @@ namespace WebApiThrottle
 
             // enforce ip rate limit as is most specific 
             string ipRule = null;
-            if (Policy.IpRules != null && ContainsIp(Policy.IpRules.Keys.ToList(), identity.ClientIp, out ipRule))
+            if (Policy.IpRules?.Any() == true && ContainsIp(Policy.IpRules.Keys.ToList(), identity.ClientIp, out ipRule))
             {
                 var limit = Policy.IpRules[ipRule].GetLimit(rateLimitPeriod);
                 if (limit > 0)


### PR DESCRIPTION
Added to the null check of rules to see if any rules exist.

This helps since in the case that a policy is stored in config with null rules, since when when it is deserialized, rules will not be null in memory due to instantiation as empty in the default ctor.  

Therefore, IP/ClientKey/Endpoint will be checked even if there are no rules.
This could be problematic since if GetRequestIdentity is overridden and IP isn't set explicitly (since from a policy perspective there are no rules or whitelists connected to IP) an exception will be thrown while parsing it.

Finally, this is a small perf boost, since if there are no rules, none of the rule related code is run.